### PR TITLE
Fixed preparing params for request

### DIFF
--- a/src/AddressValidationRequest.php
+++ b/src/AddressValidationRequest.php
@@ -14,13 +14,18 @@ class AddressValidationRequest extends AbstractRequest
 
   public function getAddresses()
   {
-      return $this->addresses;
+    return $this->addresses;
   }
 
   protected function getBody()
   {
-    $body = json_encode($this->addresses);
-    return $body;
+	$addressToArray = array();
+	foreach($this->addresses as $address) {
+	  $addressToArray[] = $address->toArray();
+	}
+
+	$body = json_encode($addressToArray);
+	return $body;
   }
 
   public function validateAddresses()


### PR DESCRIPTION
I did this changes because old version of this function:

protected function getBody()
{
  $body = json_encode($this->addresses);
  return $body;
}

returned empty structure - "[{},{}]" - data were lost. And we hadn't successfull response
