### PR TITLE
Add support for getting multiple address suggestions from SmartyStreets API

### DIFF
--- a/src/AddressValidationRequest.php
+++ b/src/AddressValidationRequest.php
@@ -6,6 +6,7 @@ class AddressValidationRequest extends AbstractRequest
 {
     protected $endpoint  = 'street-address';
     protected $addresses = array();
+    protected $candidates = 1;
 
     /**
      * Adds address to be validated
@@ -13,7 +14,17 @@ class AddressValidationRequest extends AbstractRequest
      */
     public function addAddress(Address $address)
     {
-      $this->addresses[] = $address;
+        $this->addresses[] = $address;
+    }
+
+    /**
+     * Set the number of candidates to get for each address
+     *
+     * @param int  $num  Number of candidates
+     */
+    public function setNumberOfCandidates($num)
+    {
+        $this->candidates = $num;
     }
 
     /**
@@ -56,7 +67,7 @@ class AddressValidationRequest extends AbstractRequest
         $addressesCollection = array();
 
         foreach ($this->addresses as $address) {
-            $addressesCollection[] = $address->toArray();
+            $addressesCollection[] = array_merge(['candidates' => $this->candidates], $address->toArray());
         }
 
         return json_encode($addressesCollection);


### PR DESCRIPTION
Currently only one suggestions is returned from the API.
# Usage:

$address = new Address();
$address->setData([
        'street' => '1 rosedale',
        'street2' => '',
        'city' => 'baltimore',
        'state' => 'MD',
        'zipcode' => '21229',
        'addressee' => 'test user'
]);

$addressValidationRequest = new AddressValidationRequest('token', 'key');
$addressValidationRequest->setNumberOfCandidates(10); // to get 10 suggestions from the api
$addressValidationRequest->addAddress($address);
$rs = $addressValidationRequest->validateAddresses();

print count($rs->getCandidates()); // will print 2
